### PR TITLE
Swap try catch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,4 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 4000
-
 CMD [ "npm", "start" ]

--- a/bin/www
+++ b/bin/www
@@ -14,7 +14,7 @@ const http = require('http');
  * Get port from environment and store in Express.
  */
 
-const port = (process.env.NODE_ENV === 'production') ? process.env.PORT : 4000;
+const port = (process.env.NODE_ENV === 'production') ? process.env.PORT : 5000;
 
 app.set('port', port);
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,23 +4,16 @@ const geosupport = require('node-geosupport');
 const router = express.Router();
 
 router.get('/:function_name', (req, res) => {
-  try {
-    geosupport[req.params.function_name](req.query)
-      .then((response) => {
-        res.json(response);
-      })
-      .catch(e => {
-        res.json({
-          error: 'something went wrong',
-          description: e,
-        });
-      });
-  } catch (e) {
-    res.json({
-      error: 'something went wrong',
-      description: e,
+  geosupport[req.params.function_name](req.query)
+    .then((response) => {
+      res.json(response);
     })
-  }
+    .catch(e => {
+      res.json({
+        error: 'something went wrong',
+        description: e,
+      });
+    });
 });
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,6 +8,12 @@ router.get('/:function_name', (req, res) => {
     geosupport[req.params.function_name](req.query)
       .then((response) => {
         res.json(response);
+      })
+      .catch(e => {
+        res.json({
+          error: 'something went wrong',
+          description: e,
+        });
       });
   } catch (e) {
     res.json({


### PR DESCRIPTION
This PR includes some commits that were missing from your origin (my upstream) - they were deployed but not pushed to GH. 

More importantly, this PR removes try catch and opts for the Promise API's built-in `catch` for failure handling. The origina `try catch` will onl ywork when the callback function there is `async await`, which node express doesn't support in routing.